### PR TITLE
Persist TaskPlanning responses and authorize employees for assignments

### DIFF
--- a/app/src/main/java/com/lasec/monitoreoapp/data/database/dao/manual_workorders/create_workorders/TaskPlanningRemoteMapDao.kt
+++ b/app/src/main/java/com/lasec/monitoreoapp/data/database/dao/manual_workorders/create_workorders/TaskPlanningRemoteMapDao.kt
@@ -11,6 +11,9 @@ interface TaskPlanningRemoteMapDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMap(entity: TaskPlanningRemoteMapEntity)
 
-    @Query("SELECT taskPlanningIdRemote FROM task_planning_remote_map WHERE taskPlanningLocalId = :localId")
+    @Query("SELECT taskPlanningId FROM task_planning_remote_map WHERE taskPlanningLocalId = :localId")
     suspend fun getRemoteId(localId: Int): String?
+
+    @Query("SELECT * FROM task_planning_remote_map WHERE taskPlanningLocalId = :localId")
+    suspend fun getByLocalId(localId: Int): TaskPlanningRemoteMapEntity?
 }

--- a/app/src/main/java/com/lasec/monitoreoapp/data/database/entities/manual_workorders/create_workorders/TaskPlanningRemoteMapEntity.kt
+++ b/app/src/main/java/com/lasec/monitoreoapp/data/database/entities/manual_workorders/create_workorders/TaskPlanningRemoteMapEntity.kt
@@ -8,5 +8,12 @@ import androidx.room.Entity
 )
 data class TaskPlanningRemoteMapEntity(
     val taskPlanningLocalId: Int,
-    val taskPlanningIdRemote: String
+    val taskPlanningId: String,
+    val activityTypeId: Int,
+    val color: String,
+    val endTime: String,
+    val indexVehicleId: Int,
+    val initTime: String,
+    val placeWorkOrderId: String,
+    val quantity: Double
 )

--- a/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/AuthorizeEmployeesForAssignmentUseCase.kt
+++ b/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/AuthorizeEmployeesForAssignmentUseCase.kt
@@ -1,0 +1,30 @@
+package com.lasec.monitoreoapp.domain.usecase.manual_workorders.create_workorders
+
+import com.lasec.monitoreoapp.data.repository.manual_workorders.AuthorizedEmployeesRepository
+import com.lasec.monitoreoapp.data.repository.manual_workorders.ManualWorkOrdersRepository
+import com.lasec.monitoreoapp.data.repository.manual_workorders.create_workorders.WorkOrdersResponseRepository
+import javax.inject.Inject
+
+class AuthorizeEmployeesForAssignmentUseCase @Inject constructor(
+    private val manualWorkOrdersRepository: ManualWorkOrdersRepository,
+    private val workOrdersResponseRepository: WorkOrdersResponseRepository,
+    private val authorizedEmployeesRepository: AuthorizedEmployeesRepository
+) {
+    /**
+     * Autoriza el indexEmployeeId del TaskAssignment.
+     * Lanza error si no hay workOrderId vinculado (asegúrate de haber corrido SaveWorkOrderResponseUseCase antes).
+     */
+    suspend operator fun invoke(assignmentLocalId: Int) {
+        val workOrderId = workOrdersResponseRepository.getWorkOrderIdForAssignment(assignmentLocalId)
+            ?: error("No se encontró workOrderId para assignmentLocalId=$assignmentLocalId. ¿Guardaste la respuesta de WorkOrders y los links?")
+
+        val assignment = manualWorkOrdersRepository.getAssignmentByLocalId(assignmentLocalId)
+        val indexEmployeeId = assignment.indexEmployeeId
+
+        val resp = authorizedEmployeesRepository.postAuthorizedEmployees(workOrderId, indexEmployeeId)
+        if (!resp.isSuccessful) {
+            val err = resp.errorBody()?.string()
+            error("Fallo autorizando empleado $indexEmployeeId para WO $workOrderId. HTTP ${'$'}{resp.code()} ${'$'}{err ?: ""}")
+        }
+    }
+}

--- a/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/PostAllTasksPlanningsForAssignmentUseCase.kt
+++ b/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/PostAllTasksPlanningsForAssignmentUseCase.kt
@@ -1,7 +1,5 @@
 package com.lasec.monitoreoapp.domain.usecase.manual_workorders.create_workorders
 
-import com.lasec.monitoreoapp.data.database.dao.manual_workorders.create_workorders.TaskPlanningRemoteMapDao
-import com.lasec.monitoreoapp.data.database.entities.manual_workorders.create_workorders.TaskPlanningRemoteMapEntity
 import com.lasec.monitoreoapp.data.remote.dto.TasksPlanningResponse
 import com.lasec.monitoreoapp.data.repository.manual_workorders.ManualWorkOrdersRepository
 import com.lasec.monitoreoapp.data.repository.manual_workorders.TasksPlanningRepository
@@ -13,8 +11,7 @@ import javax.inject.Inject
 class PostAllTasksPlanningsForAssignmentUseCase @Inject constructor(
     private val manualWorkOrdersRepository: ManualWorkOrdersRepository,
     private val workOrdersResponseRepository: WorkOrdersResponseRepository,
-    private val tasksPlanningRepo: TasksPlanningRepository,
-    private val taskPlanningRemoteMapDao: TaskPlanningRemoteMapDao
+    private val tasksPlanningRepo: TasksPlanningRepository
 ) {
     suspend operator fun invoke(assignmentLocalId: Int): List<TasksPlanningResponse> = withContext(Dispatchers.IO) {
         val plannings = manualWorkOrdersRepository.getPlanningsByAssignmentLocalId(assignmentLocalId)
@@ -45,15 +42,7 @@ class PostAllTasksPlanningsForAssignmentUseCase @Inject constructor(
                 error("Error al postear TaskPlanning: HTTP ${response.code()} - ${response.errorBody()?.string()}")
             }
 
-            val body = response.body()!!
-            results += body
-
-            taskPlanningRemoteMapDao.insertMap(
-                TaskPlanningRemoteMapEntity(
-                    taskPlanningLocalId = tp.taskPlanningLocalId,
-                    taskPlanningIdRemote = body.taskPlanningId
-                )
-            )
+            results += response.body()!!
         }
 
         results

--- a/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/RegisterAndPostWorkOrderUseCase.kt
+++ b/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/RegisterAndPostWorkOrderUseCase.kt
@@ -12,7 +12,9 @@ class RegisterAndPostWorkOrderUseCase @Inject constructor(
     private val postFromLocal: PostWorkOrdersFromLocalUseCase,
     private val saveWoResponse: SaveWorkOrderResponseUseCase,
     private val authorizeVehiclesForAssignment: AuthorizeVehiclesForAssignmentUseCase,
-    private val postAllTasksPlannings: PostAllTasksPlanningsForAssignmentUseCase
+    private val authorizeEmployeesForAssignment: AuthorizeEmployeesForAssignmentUseCase,
+    private val postAllTasksPlannings: PostAllTasksPlanningsForAssignmentUseCase,
+    private val saveTpResponse: SaveTpResponseUseCase
 
 ) {
     /**
@@ -36,7 +38,12 @@ class RegisterAndPostWorkOrderUseCase @Inject constructor(
         )
 
         authorizeVehiclesForAssignment(assignmentLocalId)
+        authorizeEmployeesForAssignment(assignmentLocalId)
         val tpResponses: List<TasksPlanningResponse> = postAllTasksPlannings(assignmentLocalId)
+        saveTpResponse(
+            assignmentLocalId = assignmentLocalId,
+            responses = tpResponses
+        )
 
 
 

--- a/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/SaveTpResponseUseCase.kt
+++ b/app/src/main/java/com/lasec/monitoreoapp/domain/usecase/manual_workorders/create_workorders/SaveTpResponseUseCase.kt
@@ -1,0 +1,45 @@
+package com.lasec.monitoreoapp.domain.usecase.manual_workorders.create_workorders
+
+import com.lasec.monitoreoapp.data.database.dao.manual_workorders.create_workorders.TaskPlanningRemoteMapDao
+import com.lasec.monitoreoapp.data.database.entities.manual_workorders.create_workorders.TaskPlanningRemoteMapEntity
+import com.lasec.monitoreoapp.data.remote.dto.TasksPlanningResponse
+import com.lasec.monitoreoapp.data.repository.manual_workorders.ManualWorkOrdersRepository
+import javax.inject.Inject
+
+/**
+ * Persiste las respuestas de TaskPlanning vinculado cada planificación local con los datos remotos
+ * devueltos por el backend.
+ */
+class SaveTpResponseUseCase @Inject constructor(
+    private val manualWorkOrdersRepository: ManualWorkOrdersRepository,
+    private val taskPlanningRemoteMapDao: TaskPlanningRemoteMapDao
+) {
+    suspend operator fun invoke(
+        assignmentLocalId: Int,
+        responses: List<TasksPlanningResponse>
+    ) {
+        val plannings = manualWorkOrdersRepository.getPlanningsByAssignmentLocalId(assignmentLocalId)
+        if (plannings.isEmpty() || responses.isEmpty()) return
+
+        require(plannings.size == responses.size) {
+            "El número de respuestas (${responses.size}) no coincide con la cantidad de plannings (${plannings.size})"
+        }
+
+        for ((planning, resp) in plannings.zip(responses)) {
+            taskPlanningRemoteMapDao.insertMap(
+                TaskPlanningRemoteMapEntity(
+                    taskPlanningLocalId = planning.taskPlanningLocalId,
+                    taskPlanningId = resp.taskPlanningId,
+                    activityTypeId = resp.activityTypeId,
+                    color = resp.color,
+                    endTime = resp.endTime,
+                    indexVehicleId = resp.indexVehicleId,
+                    initTime = resp.initTime,
+                    placeWorkOrderId = resp.placeWorkOrderId,
+                    quantity = resp.quantity
+                )
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- store full TaskPlanningResponse fields in `TaskPlanningRemoteMapEntity`
- persist TaskPlanning responses alongside local planning ids
- allow querying of stored TaskPlanning mappings
- authorize assignment employees using saved work order IDs

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_689e0d5f2a48832f8943ed106b34ef35